### PR TITLE
Upgrade Rootbear for Oppo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api 'com.scottyab:rootbeer-lib:0.0.7'
+    api 'com.github.scottyab:rootbeer:0.0.8'
 }


### PR DESCRIPTION
refer this [issue](https://github.com/scottyab/rootbeer/issues/109)

On certain Oppo phone, eg:
Model A37f
colorOS V3.0.0i
Android 5.1.1

The library detect that the phone is rooted but it is not. From [here](https://github.com/scottyab/rootbeer/issues/109#issuecomment-581627993) the suggestion is to use 0.0.8.

I am using the url from [jitpack](https://jitpack.io/#scottyab/rootbeer/0.0.8) because when I use `com.scottyab:rootbeer-lib:0.0.8` the app can't compile, unable to find 0.0.8.

