### PR TITLE
Migrate plugin to use android embedding v2

### DIFF
--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -1,36 +1,53 @@
 package appmire.be.flutterjailbreakdetection
 
-import android.app.Activity
+import android.content.Context
 import android.provider.Settings
 import com.scottyab.rootbeer.RootBeer
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.PluginRegistry.Registrar
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
+import io.flutter.plugin.common.BinaryMessenger
 
-class FlutterJailbreakDetectionPlugin(private val context: Activity) : MethodCallHandler {
+fun registerPlugin(messenger: BinaryMessenger, context: Context): Unit {
+    val channel = MethodChannel(messenger, "flutter_jailbreak_detection")
+    val plugin = FlutterJailbreakDetectionPlugin()
+    plugin.context = context
+    channel.setMethodCallHandler(plugin)
+}
+
+class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
+    lateinit var context: Context
+
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar): Unit {
-            if (null == registrar.activity()) {
-                return;
-            }
-            val channel = MethodChannel(registrar.messenger(), "flutter_jailbreak_detection")
-            channel.setMethodCallHandler(FlutterJailbreakDetectionPlugin(registrar.activity()))
+            registerPlugin(registrar.messenger(), registrar.context())
         }
     }
 
+    override fun onAttachedToEngine(binding: FlutterPluginBinding) {
+        registerPlugin(binding.getBinaryMessenger(), binding.getApplicationContext())
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPluginBinding) {}
+
     @android.annotation.TargetApi(17)
     fun isDevMode(): Boolean {
-        return if (Integer.valueOf(android.os.Build.VERSION.SDK) == 16) {
-            Settings.Secure.getInt(context.getContentResolver(),
+        return when {
+            Integer.valueOf(android.os.Build.VERSION.SDK) == 16 -> {
+                Settings.Secure.getInt(context.contentResolver,
                     Settings.Secure.DEVELOPMENT_SETTINGS_ENABLED, 0) != 0
-        } else if (Integer.valueOf(android.os.Build.VERSION.SDK) >= 17) {
-            Settings.Secure.getInt(context.getContentResolver(),
+            }
+            Integer.valueOf(android.os.Build.VERSION.SDK) >= 17 -> {
+                Settings.Secure.getInt(context.contentResolver,
                     Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) != 0
-        } else
-            false
+            }
+            else -> false
+        }
     }
 
     override fun onMethodCall(call: MethodCall, result: Result): Unit {


### PR DESCRIPTION
Hi,
I checked that you have [an issue](https://github.com/jeroentrappers/flutter_jailbreak_detection/issues/14) reported that the plugin should support android embedding v2.

Here is a required change. Let me know if you see any other modification needed.