### PR TITLE
Added arg jailbroken method to allow for disabling RootBeer logging

### DIFF
--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            Log.d(call.arguments)
+            Log.e(call.arguments)
             val setLogging: Boolean = call.arguments<Boolean>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.argument<Boolean?>("setLogging") == true
+            val setLogging = call.argument<Boolean?>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging: Boolean = call.argument("setLogging")
+            val setLogging: Boolean = call.arguments<Boolean>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,6 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
+            Log.d(call.arguments)
             val setLogging: Boolean = call.arguments<Boolean>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.argument("setLogging")
+            val setLogging: Boolean = call.argument("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,8 +41,8 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            // val setLogging = call.argument<Boolean?>("setLogging") == true
-            rootBeer.setLogging(false)
+            val setLogging = call.argument<Boolean?>("setLogging") == true
+            rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {
             result.success(isDevMode())

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,8 +41,8 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.argument<Boolean?>("setLogging") == true
-            rootBeer.setLogging(setLogging)
+            // val setLogging = call.argument<Boolean?>("setLogging") == true
+            rootBeer.setLogging(false)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {
             result.success(isDevMode())

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,8 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            Log.e(call.arguments)
-            val setLogging by Boolean = call.arguments<Boolean>("setLogging")
+            val setLogging = call.arguments<Boolean?>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -42,7 +42,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
             Log.e(call.arguments)
-            val setLogging: Boolean = call.arguments<Boolean>("setLogging")
+            val setLogging by Boolean = call.arguments<Boolean>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.arguments<Boolean?>("setLogging")
+            val setLogging = call.argument<Boolean?>("setLogging") == true
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,8 +41,8 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.argument<Boolean?>("setLogging")
-            rootBeer.setLogging(setLogging)
+            val setLoggingValue = call.argument<Boolean?>("setLogging") == true
+            rootBeer.setLogging(setLoggingValue)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {
             result.success(isDevMode())

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.method.arguments.setLogging
+            val setLogging = call.argument<Boolean>("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,7 +41,7 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
-            val setLogging = call.argument<Boolean>("setLogging")
+            val setLogging = call.argument("setLogging")
             rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {

--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -41,6 +41,8 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
+            val setLogging = call.method.arguments.setLogging
+            rootBeer.setLogging(setLogging)
             result.success(rootBeer.isRooted)
         } else if (call.method.equals("developerMode")) {
             result.success(isDevMode())

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class _MyAppState extends State<MyApp> {
     bool developerMode;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      jailbroken = await FlutterJailbreakDetection.jailbroken;
+      jailbroken = await FlutterJailbreakDetection.jailbroken();
       developerMode = await FlutterJailbreakDetection.developerMode;
     } on PlatformException {
       jailbroken = true;
@@ -52,10 +52,14 @@ class _MyAppState extends State<MyApp> {
         appBar: AppBar(
           title: const Text('Jailbroken plugin example app'),
         ),
-        body:  Center(
-          child: Column( mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[Text('Jailbroken: ${_jailbroken == null ? "Unknown" : _jailbroken! ? "YES" : "NO"}'),
-            Text('Developer mode: ${_developerMode == null ? "Unknown" : _developerMode! ? "YES" : "NO"}')
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                  'Jailbroken: ${_jailbroken == null ? "Unknown" : _jailbroken! ? "YES" : "NO"}'),
+              Text(
+                  'Developer mode: ${_developerMode == null ? "Unknown" : _developerMode! ? "YES" : "NO"}')
             ],
           ),
         ),

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -7,8 +7,8 @@ class FlutterJailbreakDetection {
       const MethodChannel('flutter_jailbreak_detection');
 
   static Future<bool> jailbroken({bool setLogging = true}) async {
-    bool? jailbroken =
-        await _channel.invokeMethod<bool>('jailbroken', [setLogging]);
+    bool? jailbroken = await _channel
+        .invokeMethod<bool>('jailbroken', {"setLogging": setLogging});
     return jailbroken ?? true;
   }
 

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -6,8 +6,9 @@ class FlutterJailbreakDetection {
   static const MethodChannel _channel =
       const MethodChannel('flutter_jailbreak_detection');
 
-  static Future<bool> get jailbroken async {
-    bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken');
+  static Future<bool> jailbroken({bool setLogging = true}) async {
+    bool? jailbroken =
+        await _channel.invokeMethod<bool>('jailbroken', [setLogging]);
     return jailbroken ?? true;
   }
 

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -7,8 +7,9 @@ class FlutterJailbreakDetection {
       const MethodChannel('flutter_jailbreak_detection');
 
   static Future<bool> jailbroken({bool setLogging = true}) async {
-    bool? jailbroken = await _channel
-        .invokeMethod<bool>('jailbroken', {"setLogging": setLogging});
+    bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken', [
+      <String, bool>{"setLogging": setLogging}
+    ]);
     return jailbroken ?? true;
   }
 

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -6,10 +6,12 @@ class FlutterJailbreakDetection {
   static const MethodChannel _channel =
       const MethodChannel('flutter_jailbreak_detection');
 
-  static Future<bool> jailbroken({bool setLogging = true}) async {
-    bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken', [
-      {"setLogging": setLogging}
-    ]);
+  static Future<bool> get jailbroken async {
+    bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken');
+    // bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken', [
+    //   {"setLogging": setLogging}
+    // ]);
+
     return jailbroken ?? true;
   }
 

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -6,11 +6,9 @@ class FlutterJailbreakDetection {
   static const MethodChannel _channel =
       const MethodChannel('flutter_jailbreak_detection');
 
-  static Future<bool> get jailbroken async {
-    bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken');
-    // bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken', [
-    //   {"setLogging": setLogging}
-    // ]);
+  static Future<bool> jailbroken({bool setLogging = true}) async {
+    bool? jailbroken = await _channel.invokeMethod<bool>(
+        'jailbroken', <String, dynamic>{"setLogging": setLogging});
 
     return jailbroken ?? true;
   }

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -8,7 +8,7 @@ class FlutterJailbreakDetection {
 
   static Future<bool> jailbroken({bool setLogging = true}) async {
     bool? jailbroken = await _channel.invokeMethod<bool>('jailbroken', [
-      <String, bool>{"setLogging": setLogging}
+      {"setLogging": setLogging}
     ]);
     return jailbroken ?? true;
   }


### PR DESCRIPTION
We had some feedback on our application that the logging from RootBeer that appears in LogCat on Android was a minor security risk that could help attackers implementing a root detection bypass.
I added an argument to the jailbroken method to set the RootBeer setLogging method.
Open to any feedback on the change!