### PR TITLE
jail break details with failure message in iOS

### DIFF
--- a/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
+++ b/android/src/main/kotlin/appmire/be/flutterjailbreakdetection/FlutterJailbreakDetectionPlugin.kt
@@ -42,6 +42,9 @@ class FlutterJailbreakDetectionPlugin : FlutterPlugin, MethodCallHandler {
         if (call.method.equals("jailbroken")) {
             val rootBeer = RootBeer(context)
             result.success(rootBeer.isRooted)
+        } else if (call.method.equals("jailbrokenDetails")) {
+            val rootBeer = RootBeer(context)
+            result.success("{\"status\": ${rootBeer.isRooted}, \"message\": \"For Compatibililty\"}")
         } else if (call.method.equals("developerMode")) {
             result.success(isDevMode())
         } else {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   bool? _jailbroken;
+  JailbreakDetails? _jailbrokenDetails;
   bool? _developerMode;
 
   @override
@@ -24,13 +25,16 @@ class _MyAppState extends State<MyApp> {
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
     bool jailbroken;
+    JailbreakDetails jailbrokenDetails;
     bool developerMode;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
       jailbroken = await FlutterJailbreakDetection.jailbroken;
+      jailbrokenDetails = await FlutterJailbreakDetection.jailbrokenDetails;
       developerMode = await FlutterJailbreakDetection.developerMode;
     } on PlatformException {
       jailbroken = true;
+      jailbrokenDetails = JailbreakDetails({});
       developerMode = true;
     }
 
@@ -41,6 +45,7 @@ class _MyAppState extends State<MyApp> {
 
     setState(() {
       _jailbroken = jailbroken;
+      _jailbrokenDetails = jailbrokenDetails;
       _developerMode = developerMode;
     });
   }
@@ -55,6 +60,7 @@ class _MyAppState extends State<MyApp> {
         body:  Center(
           child: Column( mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[Text('Jailbroken: ${_jailbroken == null ? "Unknown" : _jailbroken! ? "YES" : "NO"}'),
+            Text(_jailbrokenDetails.toString()),
             Text('Developer mode: ${_developerMode == null ? "Unknown" : _developerMode! ? "YES" : "NO"}')
             ],
           ),

--- a/ios/Classes/SwiftFlutterJailbreakDetectionPlugin.swift
+++ b/ios/Classes/SwiftFlutterJailbreakDetectionPlugin.swift
@@ -15,6 +15,11 @@ public class SwiftFlutterJailbreakDetectionPlugin: NSObject, FlutterPlugin {
             let check2 = IOSSecuritySuite.amIJailbroken()
             result(check2)
             break
+        case "jailbrokenDetails":
+            let details = IOSSecuritySuite.amIJailbrokenWithFailMessage()
+            let m = details.failMessage.isEmpty ? "" : details.failMessage
+            result("{\"status\": \(details.jailbroken), \"message\": \"\(m)\"}")
+            break
         case "developerMode":
             result(IOSSecuritySuite.amIRunInEmulator())
             break

--- a/lib/flutter_jailbreak_detection.dart
+++ b/lib/flutter_jailbreak_detection.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
@@ -11,8 +12,25 @@ class FlutterJailbreakDetection {
     return jailbroken ?? true;
   }
 
+  static Future<JailbreakDetails> get jailbrokenDetails async {
+    String? details = await _channel.invokeMethod<String>('jailbrokenDetails');
+    return JailbreakDetails(jsonDecode(details ?? "{}"));
+  }
+
   static Future<bool> get developerMode async {
     bool? developerMode = await _channel.invokeMethod<bool>('developerMode');
     return developerMode ?? true;
   }
+}
+
+class JailbreakDetails {
+  bool get isJailbroken => _details['status'] ?? false;
+  String get failMessage => _details['message'] ?? '';
+
+  final Map<String, dynamic> _details;
+
+  JailbreakDetails(this._details);
+
+  @override
+  String toString() => _details.toString();
 }


### PR DESCRIPTION
Returns the failure status along with a fail message using the appropriate IOSSecuritySuite method. Could possibly be useful to get message in case of false positive.