### PR TITLE
Update build.gradle and added namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "appmire.be.flutterjailbreakdetection"
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
this is important for users with agp 8.0 , otherwise the folowing error will be expieienced

"FAILURE: Build failed with an exception.

* What went wrong: A problem occurred configuring project ':flutter_jailbreak_detection'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 2s
Error: Gradle task assembleDebug failed with exit code 1"

also remeber to remove the package name from manifest file.